### PR TITLE
Set the dodgy license to MIT in the cargo manifest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "1.1.0"
 description = "An implementation of ORCA, a local collision avoidance algorithm."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-license-file = "LICENSE"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/andriyDev/dodgy"
 


### PR DESCRIPTION
Small fix up to get crates IO to say the right thing (for the next version).