### PR TITLE
Allow specifying the margin to use for obstacles.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "dodgy"
-version = "1.1.1"
+version = "1.2.0"
 
 description = "An implementation of ORCA, a local collision avoidance algorithm."
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use obstacles::get_lines_for_agent_to_obstacle;
 
 pub use obstacles::Obstacle;
 
-pub use simulator::{AgentParameters, Simulator};
+pub use simulator::{AgentParameters, Simulator, SimulatorMargin};
 pub use visibility_set::VisibilitySet;
 
 // A single agent in the simulation.
@@ -61,16 +61,18 @@ impl Agent {
   // direction to its current goal/waypoint). This new velocity is intended to
   // avoid running into the agent's `neighbours`. This is not always possible,
   // but agents will attempt to resolve any collisions in a reasonable fashion.
-  // The `time_horizon` determines how long in the future should collisions be
-  // considered between agents. The `obstacle_time_horizon` determines how long
-  // in the future should collisions be considered for obstacles. The
-  // `time_step` helps determine the velocity in cases of existing collisions,
-  // and must be positive.
+  // `obstacle_margin` determines the distance that the agent should maintain
+  // from the obstacle. The `time_horizon` determines how long in the future
+  // should collisions be considered between agents. The
+  // `obstacle_time_horizon` determines how long in the future should
+  // collisions be considered for obstacles. The `time_step` helps determine
+  // the velocity in cases of existing collisions, and must be positive.
   pub fn compute_avoiding_velocity(
     &self,
     neighbours: &[&Agent],
     obstacles: &[&Obstacle],
     preferred_velocity: Vec2,
+    obstacle_margin: f32,
     time_horizon: f32,
     obstacle_time_horizon: f32,
     time_step: f32,
@@ -80,7 +82,12 @@ impl Agent {
     let lines = obstacles
       .iter()
       .flat_map(|o| {
-        get_lines_for_agent_to_obstacle(self, o, obstacle_time_horizon)
+        get_lines_for_agent_to_obstacle(
+          self,
+          o,
+          obstacle_margin,
+          obstacle_time_horizon,
+        )
       })
       .chain(neighbours.iter().map(|neighbour| {
         self.get_line_for_neighbour(neighbour, time_horizon, time_step)

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -12,8 +12,14 @@ pub struct Simulator {
 
 pub struct AgentParameters {
   pub goal_point: Vec2,
+  pub obstacle_margin: SimulatorMargin,
   pub time_horizon: f32,
   pub obstacle_time_horizon: f32,
+}
+
+pub enum SimulatorMargin {
+  AgentRadius,
+  Distance(f32),
 }
 
 impl Simulator {
@@ -114,6 +120,10 @@ impl Simulator {
         &neighbours,
         &near_obstacles,
         parameters.goal_point - agent.position,
+        match parameters.obstacle_margin {
+          SimulatorMargin::AgentRadius => agent.radius,
+          SimulatorMargin::Distance(v) => v,
+        },
         parameters.time_horizon,
         parameters.obstacle_time_horizon,
         time_step,
@@ -131,7 +141,7 @@ impl Simulator {
 mod tests {
   use glam::Vec2;
 
-  use crate::{Agent, AgentParameters, Obstacle, Simulator};
+  use crate::{Agent, AgentParameters, Obstacle, Simulator, SimulatorMargin};
 
   macro_rules! assert_vec_near {
     ($left: expr, $right: expr, $eps: expr) => {{
@@ -162,6 +172,7 @@ mod tests {
       },
       AgentParameters {
         goal_point: Vec2::new(-10.0, 0.0),
+        obstacle_margin: SimulatorMargin::AgentRadius,
         time_horizon: 2.0,
         obstacle_time_horizon: 1.0,
       },
@@ -177,6 +188,7 @@ mod tests {
       },
       AgentParameters {
         goal_point: Vec2::new(10.0, 0.0),
+        obstacle_margin: SimulatorMargin::AgentRadius,
         time_horizon: 2.0,
         obstacle_time_horizon: 1.0,
       },

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use glam::Vec2;
 
-use crate::{Agent, Obstacle};
+use crate::{Agent, AvoidanceOptions, Obstacle};
 
 pub struct Simulator {
   agents: Vec<Agent>,
@@ -120,13 +120,15 @@ impl Simulator {
         &neighbours,
         &near_obstacles,
         parameters.goal_point - agent.position,
-        match parameters.obstacle_margin {
-          SimulatorMargin::AgentRadius => agent.radius,
-          SimulatorMargin::Distance(v) => v,
-        },
-        parameters.time_horizon,
-        parameters.obstacle_time_horizon,
         time_step,
+        &AvoidanceOptions {
+          obstacle_margin: match parameters.obstacle_margin {
+            SimulatorMargin::AgentRadius => agent.radius,
+            SimulatorMargin::Distance(v) => v,
+          },
+          time_horizon: parameters.time_horizon,
+          obstacle_time_horizon: parameters.obstacle_time_horizon,
+        },
       ));
     }
 


### PR DESCRIPTION
This allows users to choose whether obstacles should be treated as walls (with a margin of the agent radius), or as cliffs (with a small margin) or anything in between!

This requires bumping the minor version as this changes the public API.