### PR TITLE
Re-export glam::Vec2.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,9 @@ mod obstacles;
 mod simulator;
 mod visibility_set;
 
+pub use glam::Vec2;
+
 use common::*;
-use glam::Vec2;
 use linear_programming::{solve_linear_program, Line};
 use obstacles::get_lines_for_agent_to_obstacle;
 


### PR DESCRIPTION
This allows users to not have to take a dependency on glam and can still use Vec2. This also helps if we fall behind the glam version.

Fixes #13.