### PR TITLE
Use Cow for Agents/Obstacles in place of borrows.

### DIFF
--- a/crates/dodgy_2d/README.md
+++ b/crates/dodgy_2d/README.md
@@ -25,15 +25,17 @@ commented, and the public API made more flexible.
 This example uses the "raw" API.
 
 ```rust
+use std::borrow::Cow;
+
 use dodgy_2d::{Agent, AvoidanceOptions, Obstacle, Vec2};
 
-let mut agents = vec![
-  Agent {
+let mut agents: Vec<Cow<'static, Agent>> = vec![
+  Cow::Owned(Agent {
     position: Vec2::ZERO,
     velocity: Vec2::ZERO,
     radius: 1.0,
     avoidance_responsibility: 1.0,
-  },
+  }),
   // Add more agents here.
 ];
 
@@ -42,15 +44,15 @@ let goal_points = vec![
   // Add goal points for every agent.
 ];
 
-let obstacles = vec![
-  Obstacle::Closed{
+let obstacles: Vec<Cow<'static, Obstacle>> = vec![
+  Cow::Owned(Obstacle::Closed{
     vertices: vec![
       Vec2::new(-1000.0, -1000.0),
       Vec2::new(-1000.0, 1000.0),
       Vec2::new(1000.0, 1000.0),
       Vec2::new(1000.0, -1000.0),
     ],
-  },
+  }),
   // Add more obstacles here.
 ];
 
@@ -75,11 +77,12 @@ for i in 0..100 {
     let neighbours = agents[..i]
       .iter()
       .chain(agents[(i + 1)..].iter())
-      .collect::<Vec<&Agent>>();
+      .map(|agent| agent.clone())
+      .collect::<Vec<Cow<'_, Agent>>>();
     let nearby_obstacles = obstacles
       .iter()
-      .map(|obstacle| obstacle)
-      .collect::<Vec<&Obstacle>>();
+      .map(|obstacle| obstacle.clone())
+      .collect::<Vec<Cow<'_, Obstacle>>>();
 
     let agent_max_speed = 5.0;
     let preferred_velocity = (goal_points[i] - agents[i].position)
@@ -99,7 +102,7 @@ for i in 0..100 {
     new_velocities.push(avoidance_velocity);
   }
 
-  for (i, agent) in agents.iter_mut().enumerate() {
+  for (i, agent) in agents.iter_mut().map(Cow::to_mut).enumerate() {
     agent.velocity = new_velocities[i];
     agent.position += agent.velocity * delta_seconds;
   }

--- a/crates/dodgy_2d/src/lib.rs
+++ b/crates/dodgy_2d/src/lib.rs
@@ -25,6 +25,8 @@ mod obstacles;
 mod simulator;
 mod visibility_set;
 
+use std::borrow::Cow;
+
 pub use glam::Vec2;
 
 use common::*;
@@ -79,8 +81,8 @@ impl Agent {
   // velocity in cases of existing collisions, and must be positive.
   pub fn compute_avoiding_velocity(
     &self,
-    neighbours: &[&Agent],
-    obstacles: &[&Obstacle],
+    neighbours: &[Cow<'_, Agent>],
+    obstacles: &[Cow<'_, Obstacle>],
     preferred_velocity: Vec2,
     max_speed: f32,
     time_step: f32,

--- a/crates/dodgy_2d/src/simulator.rs
+++ b/crates/dodgy_2d/src/simulator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use glam::Vec2;
 
@@ -112,7 +112,7 @@ impl Simulator {
           continue;
         }
 
-        neighbours.push(&self.agents[other_index]);
+        neighbours.push(Cow::Borrowed(&self.agents[other_index]));
       }
 
       let near_obstacles = Vec::new();

--- a/crates/dodgy_3d/README.md
+++ b/crates/dodgy_3d/README.md
@@ -25,15 +25,17 @@ commented, and the public API made more flexible.
 This example uses the "raw" API.
 
 ```rust
+use std::borrow::Cow;
+
 use dodgy_3d::{Agent, AvoidanceOptions, Vec3};
 
-let mut agents = vec![
-  Agent {
+let mut agents: Vec<Cow<'static, Agent>> = vec![
+  Cow::Owned(Agent {
     position: Vec3::ZERO,
     velocity: Vec3::ZERO,
     radius: 1.0,
     avoidance_responsibility: 1.0,
-  },
+  }),
   // Add more agents here.
 ];
 
@@ -62,7 +64,8 @@ for i in 0..100 {
     let neighbours = agents[..i]
       .iter()
       .chain(agents[(i + 1)..].iter())
-      .collect::<Vec<&Agent>>();
+      .map(|agent| agent.clone())
+      .collect::<Vec<Cow<'_, Agent>>>();
 
     let agent_max_speed = 5.0;
     let preferred_velocity = (goal_points[i] - agents[i].position)
@@ -78,7 +81,7 @@ for i in 0..100 {
     new_velocities.push(avoidance_velocity);
   }
 
-  for (i, agent) in agents.iter_mut().enumerate() {
+  for (i, agent) in agents.iter_mut().map(Cow::to_mut).enumerate() {
     agent.velocity = new_velocities[i];
     agent.position += agent.velocity * delta_seconds;
   }

--- a/crates/dodgy_3d/src/lib.rs
+++ b/crates/dodgy_3d/src/lib.rs
@@ -22,6 +22,8 @@
 mod linear_programming;
 mod simulator;
 
+use std::borrow::Cow;
+
 use crate::linear_programming::{solve_linear_program, Plane};
 
 pub use glam::Vec3;
@@ -63,7 +65,7 @@ impl Agent {
   // velocity in cases of existing collisions, and must be positive.
   pub fn compute_avoiding_velocity(
     &self,
-    neighbours: &[&Agent],
+    neighbours: &[Cow<'_, Agent>],
     preferred_velocity: Vec3,
     max_speed: f32,
     time_step: f32,

--- a/crates/dodgy_3d/src/simulator.rs
+++ b/crates/dodgy_3d/src/simulator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use glam::Vec3;
 
@@ -89,7 +89,7 @@ impl Simulator {
           continue;
         }
 
-        neighbours.push(&self.agents[other_index]);
+        neighbours.push(Cow::Borrowed(&self.agents[other_index]));
       }
 
       new_velocities.push(agent.compute_avoiding_velocity(


### PR DESCRIPTION
Previously, neighbours and obstacles had to be specified as borrows. This meant if you had owned agents or obstacles, you had to create something like a Vec to hold your agents/obstacles, then a second Vec just to take borrows into it. Now with Cow you can just pass owned agents/obstacles directly into the avoidance functions.